### PR TITLE
Allow talk to accesibility bus

### DIFF
--- a/com.yubico.yubioath.json
+++ b/com.yubico.yubioath.json
@@ -18,6 +18,7 @@
     "--socket=pcsc",
     "--share=ipc",
     "--talk-name=org.kde.StatusNotifierWatcher",
+    "--talk-name=org.a11y.Bus",
     "--device=all",
     "--require-version=1.3.2"
   ],


### PR DESCRIPTION
`flatpak run --log-session-bus com.yubico.yubioath` unveils that app tries to call accessibility bus but it's denied due to lack of permission.