### PR TITLE
Fix "remember password" option

### DIFF
--- a/com.yubico.yubioath.yml
+++ b/com.yubico.yubioath.yml
@@ -15,9 +15,9 @@ finish-args:
   - --socket=fallback-x11
   - --socket=wayland
   - --socket=pcsc
-  - --socket=session-bus
   - --share=ipc
   - --talk-name=org.kde.StatusNotifierWatcher
+  - --talk-name=org.freedesktop.secrets
   - --device=all
   - --require-version=1.3.2
   - --persist=.ykman

--- a/com.yubico.yubioath.yml
+++ b/com.yubico.yubioath.yml
@@ -15,6 +15,7 @@ finish-args:
   - --socket=fallback-x11
   - --socket=wayland
   - --socket=pcsc
+  - --socket=session-bus
   - --share=ipc
   - --talk-name=org.kde.StatusNotifierWatcher
   - --device=all


### PR DESCRIPTION
Currently, "remember password" fails because the flatpak does not have permission for`org.freedesktop.secrets` on the session bus. This can be easily fixed using `flatpak override` or Flatseal. This just adds the permission by default.

Tested on Fedora Silverblue 38 Beta