### PR TITLE
chore: update description about pcsc-lite in Fedora

### DIFF
--- a/com.yubico.yubioath.appdata.xml
+++ b/com.yubico.yubioath.appdata.xml
@@ -16,7 +16,7 @@
   <developer_name>Yubico</developer_name>
 
   <description>
-    <p>NOTE: This (community) flatpak currently has issues with distros that use a patched version of pcsc-lite, like Fedora. DON'T report this to Yubico.</p>
+    <p>NOTE: This (community) flatpak currently has issues with distros that use a patched version of pcsc-lite, like Fedora 37 (or older). DON'T report this to Yubico.</p>
     <p>Generating Open Authentication (OATH) time-based TOTP and event-based HOTP one-time password codes, with the help of a YubiKey that protects the shared secrets.</p>
     <p>Features:</p>
     <ul>


### PR DESCRIPTION
According to pre-existing issues [^1] and my experience, Fedora 38 is no longer causing issues.

[^1]: https://github.com/flathub/com.yubico.yubioath/issues/35#issuecomment-1530055476