### PR TITLE
Limit build to x86-64

### DIFF
--- a/flathub.json
+++ b/flathub.json
@@ -1,3 +1,4 @@
 {
+    "only-arches": ["x86_64"],
     "disable-external-data-checker": false
 }


### PR DESCRIPTION
Upstream doesn't publish aarch64 binaries and building flutter from source is very big challenge

Fixes https://github.com/flathub/com.yubico.yubioath/issues/81