### PR TITLE
Update pcsc-lite to 2.2.3

### DIFF
--- a/com.yubico.yubioath.yml
+++ b/com.yubico.yubioath.yml
@@ -60,7 +60,8 @@ modules:
         x-checker-data:
           type: anitya
           project-id: 2611
-          versions: <: 2.3.0
+          versions:
+            <: 2.3.0
           url-template: https://pcsclite.apdu.fr/files/pcsc-lite-$version.tar.xz
 
   - name: yubioath-desktop

--- a/com.yubico.yubioath.yml
+++ b/com.yubico.yubioath.yml
@@ -60,6 +60,7 @@ modules:
         x-checker-data:
           type: anitya
           project-id: 2611
+          versions: <: 2.3.0
           url-template: https://pcsclite.apdu.fr/files/pcsc-lite-$version.tar.xz
 
   - name: yubioath-desktop

--- a/com.yubico.yubioath.yml
+++ b/com.yubico.yubioath.yml
@@ -55,12 +55,12 @@ modules:
       - /lib/libpcsclite.so
     sources:
       - type: archive
-        url: https://pcsclite.apdu.fr/files/pcsc-lite-2.0.1.tar.bz2
-        sha256: 5edcaf5d4544403bdab6ee2b5d6c02c6f97ea64eebf0825b8d0fa61ba417dada
+        url: https://pcsclite.apdu.fr/files/pcsc-lite-2.2.3.tar.xz
+        sha256: cab1e62755713f62ce1b567954dbb0e9a7e668ffbc3bbad3ce85c53f8f4e00a4
         x-checker-data:
           type: anitya
           project-id: 2611
-          url-template: https://pcsclite.apdu.fr/files/pcsc-lite-$version.tar.bz2
+          url-template: https://pcsclite.apdu.fr/files/pcsc-lite-$version.tar.xz
 
   - name: yubioath-desktop
     buildsystem: simple


### PR DESCRIPTION
This is the highest version we can go before breaking compatibility with older versions.