### PR TITLE
yubioath-desktop: Update yubico-authenticator-7.1.1-linux.tar.gz to 7.2.0

### DIFF
--- a/com.yubico.yubioath.appdata.xml
+++ b/com.yubico.yubioath.appdata.xml
@@ -44,8 +44,11 @@
   </screenshots>
 
   <releases>
-      <release version="7.1.1" date="2024-10-30">
+      <release version="7.2.0" date="2025-03-26">
          <description></description>
+      </release>
+      <release version="7.1.1" date="2024-10-30">
+         <description/>
       </release>
       <release version="7.1.0" date="2024-09-25">
          <description/>

--- a/com.yubico.yubioath.appdata.xml
+++ b/com.yubico.yubioath.appdata.xml
@@ -45,7 +45,15 @@
 
   <releases>
       <release version="7.2.0" date="2025-03-26">
-         <description></description>
+        <description>
+          <ul>
+            <li>Android: Add support for Toggle Applications.</li>
+            <li>UI: Improve usability of several dialogs in the app.</li>
+            <li>UI: Move custom icons from Accounts to Settings, and use for Passkeys </li>as well.
+            <li>UI: Language is now explicitly configurable in Settings.</li>
+            <li>Bug fixes and improvements.</li>
+          </ul>
+        </description>
       </release>
       <release version="7.1.1" date="2024-10-30">
          <description/>

--- a/com.yubico.yubioath.yml
+++ b/com.yubico.yubioath.yml
@@ -61,8 +61,8 @@ modules:
       - install -Dm644 linux_support/com.yubico.yubioath.png /app/share/icons/hicolor/128x128/apps/$FLATPAK_ID.png
     sources:
       - type: archive
-        url: https://github.com/Yubico/yubioath-flutter/releases/download/7.1.1/yubico-authenticator-7.1.1-linux.tar.gz
-        sha256: f553503a810ded105254d4b537434d4870657c5240bf43c1a47afae798ace3f2
+        url: https://github.com/Yubico/yubioath-flutter/releases/download/7.2.0/yubico-authenticator-7.2.0-linux.tar.gz
+        sha256: 5dbe2ae34ae77598c79bd5d844e9f60aca37af9bba9149c464c9a683e9b3f38d
         x-checker-data:
           type: json
           url: https://api.github.com/repos/Yubico/yubioath-flutter/releases/latest

--- a/com.yubico.yubioath.yml
+++ b/com.yubico.yubioath.yml
@@ -54,7 +54,7 @@ modules:
       - mv helper/ /app/bin/helper
       - mv lib/ /app/bin/lib
     post-install:
-      - mv linux_support/com.yubico.authenticator.desktop $FLATPAK_ID.desktop
+      - mv linux_support/com.yubico.yubioath.desktop $FLATPAK_ID.desktop
       - install -D $FLATPAK_ID.desktop -t /app/share/applications/
       - desktop-file-edit --set-icon=$FLATPAK_ID --set-key=Exec --set-value=authenticator /app/share/applications/$FLATPAK_ID.desktop
       - install -D com.yubico.yubioath.appdata.xml -t /app/share/appdata/


### PR DESCRIPTION
Copy the version update of #114 to the beta branch.