### PR TITLE
yubioath-desktop: Update yubico-authenticator-7.2.0-linux.tar.gz to 7.2.3

### DIFF
--- a/com.yubico.yubioath.appdata.xml
+++ b/com.yubico.yubioath.appdata.xml
@@ -44,6 +44,21 @@
   </screenshots>
 
   <releases>
+    <release version="7.2.3" date="2025-06-11">
+      <description>
+        <ul>
+          <li>UI: Improved language dialog.</li>
+          <li>UI: Add help dialog for keyboard shortcuts.</li>
+          <li>UI: Fixes to focus and keyboard navigation.</li>
+          <li>Linux: Fixes to the tray and application icons.</li>
+          <li>Android: Fix issue for YubiKey NEO with touch-eject enabled.</li>
+          <li>Android: Compatibility improvements for Android 16.</li>
+          <li>Binaries compiled with Flutter 3.32.1 and Python 3.13.4 (desktop).</li>
+          <li>New translations: Chinese (Simplified and Traditional), Czech, Spanish, Swedish,
+            Turkish.</li>
+        </ul>
+      </description>
+    </release>
       <release version="7.2.0" date="2025-03-26">
         <description>
           <ul>

--- a/com.yubico.yubioath.yml
+++ b/com.yubico.yubioath.yml
@@ -61,8 +61,8 @@ modules:
       - install -Dm644 linux_support/com.yubico.yubioath.png /app/share/icons/hicolor/128x128/apps/$FLATPAK_ID.png
     sources:
       - type: archive
-        url: https://github.com/Yubico/yubioath-flutter/releases/download/7.2.0/yubico-authenticator-7.2.0-linux.tar.gz
-        sha256: 5dbe2ae34ae77598c79bd5d844e9f60aca37af9bba9149c464c9a683e9b3f38d
+        url: https://github.com/Yubico/yubioath-flutter/releases/download/7.2.3/yubico-authenticator-7.2.3-linux.tar.gz
+        sha256: 05a6127bd58481780649026bf8dcc73020eb940512971a81d765c6c0e4a2bb7d
         x-checker-data:
           type: json
           url: https://api.github.com/repos/Yubico/yubioath-flutter/releases/latest


### PR DESCRIPTION
Manual update of https://github.com/Yubico/yubioath-flutter since the Flathub Bot does not seem to work on the beta branch