### PR TITLE
Make pcsc-lite compatible with versions from before and after the protocol bump in pcsc 2.3.0

### DIFF
--- a/pcsc-lite/negotiate_protocol.diff
+++ b/pcsc-lite/negotiate_protocol.diff
@@ -1,0 +1,28 @@
+diff --git a/src/winscard_clnt.c b/src/winscard_clnt.c
+index b9c900e..4b84ee8 100644
+--- a/src/winscard_clnt.c
++++ b/src/winscard_clnt.c
+@@ -600,7 +600,22 @@ static LONG SCardEstablishContextTH(DWORD dwScope,
+ 			goto cleanup;
+ 		}
+ 
+-		Log3(PCSC_LOG_INFO, "Server is protocol version %d:%d",
++		if (veStr.rv != SCARD_S_SUCCESS){
++			if (veStr.minor == 4 && PROTOCOL_VERSION_MINOR == 5){
++				Log1(PCSC_LOG_INFO, "Reading from server again, mismatch");
++
++				veStr.major = PROTOCOL_VERSION_MAJOR;
++				veStr.minor = 4;
++				veStr.rv = SCARD_S_SUCCESS;
++				rv = MessageSendWithHeader(CMD_VERSION, dwClientID, sizeof(veStr),
++					&veStr);
++
++				Log1(PCSC_LOG_INFO, "Sent to server");
++				rv = MessageReceive(&veStr, sizeof(veStr), dwClientID);
++			}
++		}
++
++		Log3(PCSC_LOG_INFO, "Negotiated protocol version %d:%d",
+ 			veStr.major, veStr.minor);
+ 
+ 		if (veStr.rv != SCARD_S_SUCCESS)


### PR DESCRIPTION
This relates to #101, I ran into the same issue with the digidoc flatpak. This is a little patch I made that does some rudimentary protocol negotiation to make the pcsc-lite running inside the flatpak agnostic to the version of the pcsc daemon running on the host.

I don't have my yubikey at the moment so cannot do a proper test. If you test the build, please also post the output of `pcscd -v`

There's a little more info here https://github.com/flathub/ee.ria.qdigidoc4/issues/5