### PR TITLE
Fix screenshots cannot be moved in some distributions

### DIFF
--- a/gnome-screenshot
+++ b/gnome-screenshot
@@ -26,17 +26,14 @@ def on_response(output_filename: str) -> Callable[[Any, Any, str, GLib.Variant],
         if signal_name == "Response":
             if result[0] == 0:
                 uri = result[1]["uri"]
+                file_path = Gio.File.new_for_uri(uri).get_path()
 
-                # Strip file://
-                if uri.startswith("file://"):
-                    uri = uri[len("file://") :]
-
-                shutil.copyfile(uri, output_filename)
+                shutil.copyfile(file_path, output_filename)
                 # Try to remove the screenshot as it contains the 2FA secret.
                 # Removing the file may fail on some systems, so ignore any errors.
                 # https://github.com/flathub/com.yubico.yubioath/issues/121
                 try:
-                    os.remove(uri)
+                    os.remove(file_path)
                 except Exception:
                     pass
 

--- a/gnome-screenshot
+++ b/gnome-screenshot
@@ -8,6 +8,7 @@
 # Based on this forum post
 # https://discourse.gnome.org/t/take-screenshot-in-gnome-environment-via-its-dbus-api/21144/4
 
+import os
 import shutil
 import sys
 from typing import Any
@@ -30,10 +31,17 @@ def on_response(output_filename: str) -> Callable[[Any, Any, str, GLib.Variant],
                 if uri.startswith("file://"):
                     uri = uri[len("file://") :]
 
-                shutil.move(uri, output_filename)
+                shutil.copyfile(uri, output_filename)
+                # Try to remove the screenshot as it contains the 2FA secret.
+                # Removing the file may fail on some systems, so ignore any errors.
+                # https://github.com/flathub/com.yubico.yubioath/issues/121
+                try:
+                    os.remove(uri)
+                except Exception:
+                    pass
 
             else:
-                print("Failed")
+                print("Calling the screenshot portal failed", file=sys.stderr)
         LOOP.quit()
 
     return _inner_on_response
@@ -55,7 +63,7 @@ def main() -> None:
     if len(sys.argv) == 3 and sys.argv[1] == "-f":
         output_filename: str = sys.argv[2]
     else:
-        print("Did not specify filename to save")
+        print("Did not specify filename to save", file=sys.stderr)
         sys.exit(2)
 
     proxy: Gio.DBusProxy = get_proxy(


### PR DESCRIPTION
As reported in #121 in some Linux distributions the screenshot files
cannot be deleted. Handle this case by simply ignoring any errors.
Still try to delete the screenshot files, as they can accumulate in the
XDG_PICTURES_DIR folder and they contain the 2FA secrets.

Closes #121