### PR TITLE
Build pcsclite with provided patch

### DIFF
--- a/com.yubico.yubioath.yml
+++ b/com.yubico.yubioath.yml
@@ -42,6 +42,8 @@ modules:
           type: anitya
           project-id: 2611
           url-template: https://pcsclite.apdu.fr/files/pcsc-lite-$version.tar.xz
+      - type: patch
+        path: pcsc-lite/negotiate_protocol.diff
 
   - name: yubioath-desktop
     buildsystem: simple


### PR DESCRIPTION
The pcsclite patch was committed to the repo but not referenced in manifest

Fixes https://github.com/flathub/com.yubico.yubioath/pull/120

Fixes https://github.com/flathub/com.yubico.yubioath/issues/128